### PR TITLE
Config setting for build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ From this directory run: `npm start` and an HTTP server will spin up and your br
 ## Build for production
 
 Configure the deployment path for the build with in [package.json](package.json) in this directory.
-Currently it is set to `"homepage": "/ruleset-generator/"` to meet the zgif.org requirements
+Currently it is set to `"homepage": "/ruleset-generator/"` to meet the zgif.org requirements.
 
 From this directory run: `npm run build` to get the build artefact in /build.
 

--- a/README.md
+++ b/README.md
@@ -11,23 +11,30 @@ From this directory run: `npm install`.
 
 From this directory run: `npm start` and an HTTP server will spin up and your browser will open.
 
+## Build for production
+
+Configure the deployment path for the build with in [package.json](package.json) in this directory.
+Currently it is set to `"homepage": "/ruleset-generator/"` to meet the zgif.org requirements
+
+From this directory run: `npm run build` to get the build artefact in /build.
+
 ## Usage
 
 ### Limitations
 
-* This application breaks if the XSD is invalid; e.g. in http://zgif.org/api/ruleset/subset_52.xsd there's no `Account`.
-* It's not possible to download with the mocked API
-* It's not possible to consume the live API locally unless CORS is disabled in your browser. On Chrome you can achieve that by using [this extension](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi?hl=en). _Note that you should the extension disables a good security feature of Google Chrome, don't forget to disable the extension after using it._
+- This application breaks if the XSD is invalid; e.g. in http://zgif.org/api/ruleset/subset_52.xsd there's no `Account`.
+- It's not possible to download with the mocked API
+- It's not possible to consume the live API locally unless CORS is disabled in your browser. On Chrome you can achieve that by using [this extension](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi?hl=en). _Note that you should the extension disables a good security feature of Google Chrome, don't forget to disable the extension after using it._
 
 For a full list of features that are yet to be done, please refer to our `TODO.md` file.
 
 ### Instructions
 
-1. Paste or type a URL pointing to a zgif XSD that should be used as base. E.g. http://zgif.org/api/ruleset/dummy_ruleset.xsd
-2. Change the rule values: core, optional, not
-3. Optionally add new field or entity rules
-4. Click the button "generate ruleset" at the end of the page
-5. A new XSD should be downloaded
+1.  Paste or type a URL pointing to a zgif XSD that should be used as base. E.g. http://zgif.org/api/ruleset/dummy_ruleset.xsd
+2.  Change the rule values: core, optional, not
+3.  Optionally add new field or entity rules
+4.  Click the button "generate ruleset" at the end of the page
+5.  A new XSD should be downloaded
 
 ## Optional configuration
 
@@ -44,7 +51,7 @@ Tests and support to other browsers require the addition of polyfills and may be
 
 ### Technical
 
-* Main technologies: React, Redux, JSX, CSS
-* CSS selectors format: BEM
-* CSS pre-processor: none
-* This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
+- Main technologies: React, Redux, JSX, CSS
+- CSS selectors format: BEM
+- CSS pre-processor: none
+- This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).

--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "homepage": "/ruleset-generator/"
 }


### PR DESCRIPTION
This change makes the build artefact run from a sub folder.
There is a warning for the property "homepage": "String is not a URI: URI with a scheme is expected." 
I ignored that to keep the host flexible and it works like this.
